### PR TITLE
add lag info and adjust the order of output column

### DIFF
--- a/stormkafkamon/monitor.py
+++ b/stormkafkamon/monitor.py
@@ -29,6 +29,27 @@ def display(summary, friendly=False):
         fmt = null_fmt
 
     table = PrettyTable(['Broker', 'Topic', 'Partition', 'Earliest', 'Latest',
+                         'Depth', 'Spout', 'Current', 'Delta'])
+    table.align['broker'] = 'l'
+
+    for p in summary.partitions:
+        table.add_row([p.broker, p.topic, p.partition, p.earliest, p.latest,
+                       fmt(p.depth), p.spout, p.current, fmt(p.delta)])
+    print table.get_string(sortby='Broker')
+    print
+    print 'Number of brokers:       %d' % summary.num_brokers
+    print 'Number of partitions:    %d' % summary.num_partitions
+    print 'Total broker depth:      %s' % fmt(summary.total_depth)
+    print 'Total delta:             %s' % fmt(summary.total_delta)
+
+
+def display_lag(summary, friendly=False):
+    if friendly:
+        fmt = sizeof_fmt
+    else:
+        fmt = null_fmt
+
+    table = PrettyTable(['Broker', 'Topic', 'Partition', 'Earliest', 'Latest',
                          'Current', 'Lag', 'Spout', 'Delta', 'Depth'])
     table.align['broker'] = 'l'
 
@@ -83,6 +104,8 @@ def read_args():
                         help='Root path for Kafka Spout data in Zookeeper')
     parser.add_argument('--friendly', action='store_const', const=True,
                         help='Show friendlier data')
+    parser.add_argument('--showlag', action='store_const', const=True,
+                        help='show lag info')
     parser.add_argument('--postjson', type=str,
                         help='endpoint to post json data to')
     return parser.parse_args()
@@ -104,6 +127,8 @@ def main():
     else:
         if options.postjson:
             post_json(options.postjson, zk_data)
+        if options.showlag:
+            display_lag(zk_data, true_or_false_option(options.friendly))
         else:
             display(zk_data, true_or_false_option(options.friendly))
 

--- a/stormkafkamon/monitor.py
+++ b/stormkafkamon/monitor.py
@@ -29,18 +29,20 @@ def display(summary, friendly=False):
         fmt = null_fmt
 
     table = PrettyTable(['Broker', 'Topic', 'Partition', 'Earliest', 'Latest',
-                         'Depth', 'Spout', 'Current', 'Delta'])
+                         'Current', 'Lag', 'Spout', 'Delta', 'Depth'])
     table.align['broker'] = 'l'
 
     for p in summary.partitions:
         table.add_row([p.broker, p.topic, p.partition, p.earliest, p.latest,
-                       fmt(p.depth), p.spout, p.current, fmt(p.delta)])
+                      p.current, p.latest - p.current, p.spout, fmt(p.delta), fmt(p.depth)])
+
     print table.get_string(sortby='Broker')
     print
     print 'Number of brokers:       %d' % summary.num_brokers
     print 'Number of partitions:    %d' % summary.num_partitions
-    print 'Total broker depth:      %s' % fmt(summary.total_depth)
+    print 'Total lag:               %s' % summary.total_delta
     print 'Total delta:             %s' % fmt(summary.total_delta)
+    print 'Total broker depth:      %s' % fmt(summary.total_depth)
 
 
 def post_json(endpoint, zk_data):

--- a/stormkafkamon/zkclient.py
+++ b/stormkafkamon/zkclient.py
@@ -6,9 +6,7 @@ from kazoo.exceptions import NoNodeError
 
 ZkKafkaBroker = namedtuple('ZkKafkaBroker', ['id', 'host', 'port'])
 ZkKafkaSpout = namedtuple('ZkKafkaSpout', ['id', 'partitions'])
-ZkKafkaTopic = namedtuple(
-    'ZkKafkaTopic', [
-        'topic', 'broker', 'num_partitions'])
+ZkKafkaTopic = namedtuple('ZkKafkaTopic', ['topic', 'broker', 'num_partitions'])
 
 
 class ZkError(Exception):
@@ -78,10 +76,8 @@ class ZkClient:
         try:
             for c in self.client.get_children(spout_root):
                 partitions = []
-                for p in self.client.get_children(
-                        self._zjoin([spout_root, c])):
-                    j = json.loads(self.client.get(
-                        self._zjoin([spout_root, c, p]))[0])
+                for p in self.client.get_children(self._zjoin([spout_root, c])):
+                    j = json.loads(self.client.get(self._zjoin([spout_root, c, p]))[0])
                     if j['topology']['name'] == topology:
                         partitions.append(j)
                 s.append(ZkKafkaSpout._make([c, partitions]))


### PR DESCRIPTION
change list

1.  add lag info for offset
2.  adjust the order of output column
3.  adjust the format of some code

test result
```
[root@mty-003 stormkafkamon]# python stormkafkamon/monitor.py --zserver mty-001 --zport 2182 --topology product --spoutroot /kafkaspout --friendly
+---------+-----------+-----------+----------+------------+------------+------------+-------------------+-------------+-----------+
|  Broker |   Topic   | Partition | Earliest |   Latest   |  Current   |    Lag     |       Spout       |    Delta    |   Depth   |
+---------+-----------+-----------+----------+------------+------------+------------+-------------------+-------------+-----------+
| mty-001 | product_1 |     2     |    0     |    9758    |    9757    |     1      | product_1_spout_2 |  1.0 bytes  |   9.5KB   |
| mty-001 | product_1 |     8     |    0     | 1549922142 |   552099   | 1549370043 |  product_1_spout  |    1.4GB    |   1.4GB   |
| mty-001 | product_1 |     8     |    0     | 1549926035 | 1014938290 | 534987745  | product_1_spout_2 |   510.2MB   |   1.4GB   |
| mty-001 | product_1 |     11    |  571907  |  1573654   |   726298   |   847356   |  product_1_spout  |   827.5KB   |  978.3KB  |
| mty-001 | product_1 |     11    |  571907  |  1573654   |  1573626   |     28     | product_1_spout_2 |  28.0 bytes |  978.3KB  |
| mty-001 | product_1 |     17    | 2744610  |  8404961   |  4960706   |  3444255   |  product_1_spout  |    3.3MB    |   5.4MB   |
| mty-001 | product_1 |     17    | 2744610  |  8404967   |  8404945   |     22     | product_1_spout_2 |  22.0 bytes |   5.4MB   |
| mty-001 | product_1 |     20    |    0     |  1295422   |   882698   |   412724   |  product_1_spout  |   403.1KB   |   1.2MB   |
| mty-001 | product_1 |     20    |    0     |  1295422   |  1295413   |     9      | product_1_spout_2 |  9.0 bytes  |   1.2MB   |
| mty-001 | product_1 |     23    |    0     |    3904    |    3653    |    251     |  product_1_spout  | 251.0 bytes |   3.8KB   |
| mty-001 | product_1 |     23    |    0     |    3904    |    3904    |     0      | product_1_spout_2 |  0.0 bytes  |   3.8KB   |
| mty-002 | product_1 |     0     |    0     |    2843    |    2843    |     0      | product_1_spout_2 |  0.0 bytes  |   2.8KB   |
| mty-002 | product_1 |     3     |    0     |   668137   |   381466   |   286671   |  product_1_spout  |   280.0KB   |  652.5KB  |
| mty-002 | product_1 |     3     |    0     |   668137   |   668136   |     1      | product_1_spout_2 |  1.0 bytes  |  652.5KB  |
| mty-002 | product_1 |     9     |    0     |   737698   |   511510   |   226188   |  product_1_spout  |   220.9KB   |  720.4KB  |
| mty-002 | product_1 |     9     |    0     |   737698   |   737698   |     0      | product_1_spout_2 |  0.0 bytes  |  720.4KB  |
| mty-002 | product_1 |     12    |   362    |    362     |    362     |     0      |  product_1_spout  |  0.0 bytes  | 0.0 bytes |
| mty-002 | product_1 |     18    | 4027388  |  13235663  |  7577209   |  5658454   |  product_1_spout  |    5.4MB    |   8.8MB   |
| mty-002 | product_1 |     18    | 4027388  |  13235663  |  13235292  |    371     | product_1_spout_2 | 371.0 bytes |   8.8MB   |
| mty-002 | product_1 |     21    |    0     |   412297   |    108     |   412189   |  product_1_spout  |   402.5KB   |  402.6KB  |
| mty-002 | product_1 |     21    |    0     |   412297   |   412273   |     24     | product_1_spout_2 |  24.0 bytes |  402.6KB  |
| mty-003 | product_1 |     1     |  11815   |   23111    |   11815    |   11296    |  product_1_spout  |    11.0KB   |   11.0KB  |
| mty-003 | product_1 |     4     |    0     |   393237   |   243579   |   149658   |  product_1_spout  |   146.2KB   |  384.0KB  |
| mty-003 | product_1 |     4     |    0     |   393237   |   393237   |     0      | product_1_spout_2 |  0.0 bytes  |  384.0KB  |
| mty-003 | product_1 |     7     |    0     |  10130608  |   816228   |  9314380   |  product_1_spout  |    8.9MB    |   9.7MB   |
| mty-003 | product_1 |     7     |    0     |  10130608  |  10130495  |    113     | product_1_spout_2 | 113.0 bytes |   9.7MB   |
| mty-003 | product_1 |     10    |   384    |    384     |    384     |     0      |  product_1_spout  |  0.0 bytes  | 0.0 bytes |
| mty-003 | product_1 |     16    |    0     |   415116   |   239406   |   175710   |  product_1_spout  |   171.6KB   |  405.4KB  |
| mty-003 | product_1 |     16    |    0     |   415116   |   415105   |     11     | product_1_spout_2 |  11.0 bytes |  405.4KB  |
| mty-003 | product_1 |     19    | 2151011  |  4959175   |  3247674   |  1711501   |  product_1_spout  |    1.6MB    |   2.7MB   |
| mty-003 | product_1 |     19    | 2151011  |  4959178   |  4959167   |     11     | product_1_spout_2 |  11.0 bytes |   2.7MB   |
| mty-003 | product_1 |     22    |  149400  |   786528   |   149400   |   637128   |  product_1_spout  |   622.2KB   |  622.2KB  |
| mty-003 | product_1 |     22    |  149400  |   786528   |   786523   |     5      | product_1_spout_2 |  5.0 bytes  |  622.2KB  |
+---------+-----------+-----------+----------+------------+------------+------------+-------------------+-------------+-----------+

Number of brokers:       3
Number of partitions:    33
Total lag:               2107646145
Total delta:             2.0GB
Total broker depth:      2.9GB
```